### PR TITLE
config/database.yml: Fetch database parameters from ENV

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,11 +20,12 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: tsega
+  username: <%= ENV.fetch("RAILS_DB_USER") { dspace } %>
+  password: <%= ENV.fetch("RAILS_DB_PASS") { dspace } %>
 
 development:
   <<: *default
-  database: cgspacetest
+  database: <%= ENV.fetch("RAILS_DB_NAME") { dspace } %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
Allows us to provide these values via the systemd service which in turn gets them during the Ansible provisioning process, ie in the systemd service, with variables interpolated by Ansible during deploy:

```ini
[Unit]
Description=DSpace REST API
After=network.target

[Service]
# Foreground process (do not use --daemon in ExecStart or config.rb)
Type=simple

Environment=RAILS_DB_NAME={{ dspace_db_name }}
Environment=RAILS_DB_USER={{ rest_api_db_user }}
Environment=RAILS_DB_PASS={{ rest_api_db_password }}
...
```